### PR TITLE
Tweaks & docs to make it easier to run Persyn locally on MacOS

### DIFF
--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -1,0 +1,41 @@
+# Running Elasticsearch locally on MacOS using Docker
+
+## Install Colima
+
+```
+brew install colima
+colima start -m 4
+```
+
+[Colima](https://github.com/abiosoft/colima) is a Docker runtime with good
+support for Mac M1s.
+
+Unfortunately, you will need to give the JVM 4 gigs of RAM in order to set the
+password in the next step. Probably you can stop and restart Colima with less
+RAM after the setup is done.
+
+## Install and run the Elasticsearch container
+
+```
+docker pull elasticsearch:8.5.3
+docker volume create --name elasticsearch
+docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 \
+  -e "discovery.type=single-node" \
+  -v elasticsearch:/usr/share/elasticsearch/data \
+  elasticsearch:8.5.3
+```
+
+## Configure the Elasticsearch credentials
+
+```
+docker exec -it elasticsearch bin/elasticsearch-reset-password -a -u elastic
+```
+
+## Test the Elasticsearch credentials
+
+```
+curl -k -u elastic:<password> https://localhost:9200/
+```
+
+The `-k` option to `curl` tells it not to worry about the self-signed cert. You
+should get a JSON doc back indicating success.

--- a/interaction/install.sh
+++ b/interaction/install.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -e
 
-virtualenv --python=python3.8 env --prompt='(interact-env) '
+if [ $(uname -s) = "Darwin" ]; then
+  brew install cmake
+fi
+
+python3 -m venv --prompt='interact-env' env
 . env/bin/activate
 
 pip install -r requirements.txt

--- a/interaction/interact.py
+++ b/interaction/interact.py
@@ -55,6 +55,8 @@ class Interact():
         self.completion = LanguageModel(config=persyn_config)
 
         # Elasticsearch memory
+        verify_certs_setting = persyn_config.memory.elastic.get("verify_certs", "true")
+        verify_certs = json.loads(str(verify_certs_setting).lower()) # convert "false" -> False, "0" -> False
         self.recall = Recall(
             bot_name=persyn_config.id.name,
             bot_id=persyn_config.id.guid,
@@ -63,7 +65,7 @@ class Interact():
             auth_key=persyn_config.memory.elastic.key,
             index_prefix=persyn_config.memory.elastic.index_prefix,
             conversation_interval=600, # ten minutes
-            verify_certs=True
+            verify_certs=verify_certs
         )
 
     def dialog(self, convo):

--- a/interaction/interact.py
+++ b/interaction/interact.py
@@ -54,9 +54,17 @@ class Interact():
         # Pick a language model for completion
         self.completion = LanguageModel(config=persyn_config)
 
-        # Elasticsearch memory
+        # Elasticsearch memory:
+        # First, check if we don't want to verify TLS certs (because self-hosted Elasticsearch)
         verify_certs_setting = persyn_config.memory.elastic.get("verify_certs", "true")
         verify_certs = json.loads(str(verify_certs_setting).lower()) # convert "false" -> False, "0" -> False
+
+        # If not, disable the pesky urllib3 insecure request warning.
+        if not verify_certs:
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+        # Then create the Recall object using the Elasticsearch credentials.
         self.recall = Recall(
             bot_name=persyn_config.id.name,
             bot_id=persyn_config.id.guid,


### PR DESCRIPTION
* Install CMake via brew to build Python dependencies
* Docs on how to install ElasticSearch on MacOS using Docker
* `verify_certs` setting to allow local ElasticSearch without SSL certificate verification