### PR TITLE
Enable selection of NLP models for NER and sentiment analysis.

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -18,6 +18,14 @@ completion:
   model: text-davinci-003
   minimum_quality_score: -2.0
   temperature: 0.99
+  # spacy_model: "en_core_web_lg"
+
+# Sentiment analysis engine
+sentiment:
+  engine: "flair"
+  model: "en-sentiment"
+  # engine: "spacy"
+  # engine: "en_core_web_lg"
 
 # Chat modules. Enable one or more of these.
 chat:
@@ -52,13 +60,12 @@ memory:
 interact:
   url: http://localhost:8003
 
-# Optional: Dream image generation server (dreams.py)
-# dreams:
-#   url: http://localhost:8001
-
-#   gpus:
-#     # CUDA number and a name for each local GPU to use for image generation
-#     1: Nvidia 2080
+  # Optional: Dream image generation server (dreams.py)
+  # dreams:
+  #   url: http://localhost:8001
+  #   gpus:
+  #     # CUDA number and a name for each local GPU to use for image generation
+  #     1: Nvidia 2080
 
   # Image upload SCP destination and URL. Only required if generating images.
   # upload:

--- a/interaction/completion.py
+++ b/interaction/completion.py
@@ -6,6 +6,8 @@ import spacy
 import gpt
 import nlp_cloud
 
+from feels import Sentiment
+
 class LanguageModel():
     ''' Container for language model completion requests '''
     def __init__(
@@ -17,7 +19,9 @@ class LanguageModel():
         self.engine = config.completion.engine
         self.bot_name = config.id.name
         self.stats = Counter()
-        self.nlp = spacy.load("en_core_web_lg")
+        self.nlp = spacy.load(getattr(config.completion, "spacy_model", "en_core_web_lg"))
+        self.sentiment = Sentiment(getattr(config.sentiment, "engine", "flair"),
+                                   getattr(config.sentiment, "model", None))
         # Absolutely forbidden words
         self.forbidden = forbidden or []
         # Minimum completion reply quality. Lower numbers get more dark + sleazy.

--- a/interaction/feels.py
+++ b/interaction/feels.py
@@ -14,8 +14,12 @@ from Levenshtein import ratio
 # flair sentiment
 import flair
 
-# Only load the model once on import. Uses GPU if available.
-flair_sentiment = flair.models.TextClassifier.load('en-sentiment')
+# spacy sentiment
+import spacy
+from spacytextblob.spacytextblob import SpacyTextBlob
+
+# Only load the model once when we need it. Uses GPU if available.
+flair_sentiment = None
 
 # Not actually "all" emoji, but all the emoji we can randomly respond with.
 reply_emoji = (
@@ -311,6 +315,9 @@ def get_profanity_score(prompt):
 
 def get_flair_score(prompt):
     ''' Run the flair sentiment prediction model. Returns a float, -1.0 to 1.0 '''
+    global flair_sentiment
+    if not flair_sentiment:
+         flair_sentiment = flair.models.TextClassifier.load('en-sentiment')
     sent = flair.data.Sentence(prompt)
     flair_sentiment.predict(sent)
 
@@ -318,3 +325,24 @@ def get_flair_score(prompt):
         return -sent.labels[0].score
 
     return sent.labels[0].score
+
+class Sentiment(object):
+    def __init__(self, engine="flair", model=None):
+        self.engine = engine
+        # `model` doesn't do anything for Flair right now because we're not
+        # loading the Flair model here
+        self.model = model
+
+        if self.engine == "spacy":
+            self.nlp = spacy.load(self.model or "en_core_web_lg")
+            self.nlp.add_pipe('spacytextblob')
+
+    def get_sentiment_score(self, prompt):
+        if self.engine == "spacy":
+            doc = self.nlp(prompt)
+            return doc._.blob.polarity
+        else:
+            return get_flair_score(prompt)
+
+    def get_profanity_score(self, prompt):
+        return get_profanity_score(prompt)

--- a/interaction/gpt.py
+++ b/interaction/gpt.py
@@ -8,7 +8,7 @@ import spacy
 
 from ftfy import fix_text
 
-from feels import get_flair_score, get_profanity_score, closest_emoji
+from feels import Sentiment, closest_emoji
 
 # Color logging
 from color_logging import ColorLog
@@ -25,7 +25,8 @@ class GPT():
         api_base,
         model_name,
         forbidden=None,
-        nlp=None
+        nlp=None,
+        sentiment=None
         ):
         self.bot_name = bot_name
         self.min_score = min_score
@@ -33,6 +34,7 @@ class GPT():
         self.forbidden = forbidden or []
         self.stats = Counter()
         self.nlp = nlp or spacy.load("en_core_web_lg")
+        self.sentiment = sentiment or Sentiment()
 
         if model_name.startswith('text-davinci-'):
             self.max_prompt_length = 4000 # tokens
@@ -284,8 +286,8 @@ class GPT():
                 goal_bonus = 0.0
 
             all_scores = {
-                "flair": get_flair_score(raw),
-                "profanity": get_profanity_score(raw),
+                "flair": self.sentiment.get_sentiment_score(raw),
+                "profanity": self.sentiment.get_profanity_score(raw),
                 "topic_bonus": topic_bonus,
                 "goal_bonus": goal_bonus
             }

--- a/interaction/requirements.txt
+++ b/interaction/requirements.txt
@@ -15,3 +15,4 @@ shortuuid
 wikipedia
 spacy
 coreferee
+spacytextblob

--- a/utils/config.py
+++ b/utils/config.py
@@ -48,4 +48,6 @@ def load_config():
             except (AttributeError, TypeError, ValueError):
                 raise RuntimeError("chat.discord.webhook is not valid. Check your yaml config.")
 
+    config.setdefault('sentiment', {})
+
     return DotWiz(config)


### PR DESCRIPTION
* Add `config.completion.spacy_model` to allow choosing a different model for NER. Defaults to `en_core_web_lg`.
* Add `config.sentiment.engine` and `config.sentiment.model` to allow for switching between Flair and spacytextblob. `engine` defaults to `flair`.